### PR TITLE
Include ossec-batch-manager.pl in agent package

### DIFF
--- a/ossec-hids-agent/debian/patches/01_makefile.patch
+++ b/ossec-hids-agent/debian/patches/01_makefile.patch
@@ -2,7 +2,7 @@ Index: ossec-hids-agent-2.8.2/Makefile
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
 +++ ossec-hids-agent-2.8.2/Makefile	2015-06-15 03:15:51.083134760 +0000
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,55 @@
 +#
 +# Santiago Bassett <santiago.bassett@gmail.com>
 +# 06/15/2015
@@ -30,7 +30,7 @@ Index: ossec-hids-agent-2.8.2/Makefile
 +
 +install:
 +	mkdir -p $(DIR)
-+	(cd $(DIR); mkdir -p logs bin queue queue/ossec queue/alerts queue/syscheck queue/diff queue/rids)
++	(cd $(DIR); mkdir -p logs bin queue queue/ossec queue/alerts queue/syscheck queue/diff queue/rids contrib)
 +	(cd $(DIR); mkdir -p var var/run etc etc/init.d etc/shared active-response active-response/bin agentless .ssh)
 +	cp -pr src/rootcheck/db/*.txt $(DIR)/etc/shared/
 +	chmod -x $(DIR)/etc/shared/*.txt
@@ -47,6 +47,7 @@ Index: ossec-hids-agent-2.8.2/Makefile
 +	cp -pr src/init/ossec-client.sh ${DIR}/bin/ossec-control
 +	cp -pr src/addagent/manage_agents ${DIR}/bin/
 +	cp -pr contrib/util.sh ${DIR}/bin/
++	cp -p contrib/ossec-batch-manager.pl $(DIR)/contrib/
 +	sh src/init/fw-check.sh execute > /dev/null
 +	cp -pr active-response/*.sh ${DIR}/active-response/bin/
 +	cp -pr active-response/firewalls/*.sh ${DIR}/active-response/bin/


### PR DESCRIPTION
Thank you for including ossec-batch-manager.pl in the server package. Unfortunately it also needs to be included in the agent package, according to jtimberman/ossec-cookbook#7. I have decided to use authd rather than this script so I'm afraid I haven't tested this whatsoever. I'm just fixing this because I know my cookbook contribution will break without it.
